### PR TITLE
45 Add a pool of available outputTransactions to Block or Chain

### DIFF
--- a/blockchain/src/blockchain/Block.java
+++ b/blockchain/src/blockchain/Block.java
@@ -43,7 +43,7 @@ public class Block {
   /**
    * The list of unconsumed TransactionOutputs. Those outputs were not yet used up by Transactions.
    */
-  private List<TransactionOutput> unconsumedOutputs = new ArrayList<>();
+  private List<TransactionOutput> unconsumedOutputs;
 
   /**
    * Constructor for the Block class.
@@ -92,9 +92,7 @@ public class Block {
     }
 
     transaction.inputs.forEach(
-        transactionInput -> {
-          unconsumedOutputs.remove(transactionInput.transactionOut);
-        });
+        transactionInput -> unconsumedOutputs.remove(transactionInput.transactionOut));
     unconsumedOutputs.addAll(transaction.processTransaction());
 
     if (transaction.validate()) {

--- a/blockchain/src/blockchain/Block.java
+++ b/blockchain/src/blockchain/Block.java
@@ -2,20 +2,29 @@ package blockchain;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /** This is a Block class. Represents a single block in the blockchain. */
 public class Block {
+  private List<TransactionOutput> unconsumedOutputs;
+
   /**
    * Constructor for the Block class.
    *
    * @param previousHash the hash of the previous Block
    * @param blockVersion the version of this Block
    * @param miningDifficulty the mining difficulty of this Block
+   * @param unconsumedOutputs the pool of unconsumed TransactionOutputs
    */
-  public Block(String previousHash, String blockVersion, int miningDifficulty) {
+  public Block(
+      String previousHash,
+      String blockVersion,
+      int miningDifficulty,
+      List<TransactionOutput> unconsumedOutputs) {
     this.previousHash = previousHash;
     this.blockVersion = blockVersion;
     this.miningDifficulty = miningDifficulty;
+    this.unconsumedOutputs = unconsumedOutputs;
 
     id = this.calculateId();
   }

--- a/blockchain/src/blockchain/Block.java
+++ b/blockchain/src/blockchain/Block.java
@@ -6,29 +6,6 @@ import java.util.List;
 
 /** This is a Block class. Represents a single block in the blockchain. */
 public class Block {
-  private List<TransactionOutput> unconsumedOutputs;
-
-  /**
-   * Constructor for the Block class.
-   *
-   * @param previousHash the hash of the previous Block
-   * @param blockVersion the version of this Block
-   * @param miningDifficulty the mining difficulty of this Block
-   * @param unconsumedOutputs the pool of unconsumed TransactionOutputs
-   */
-  public Block(
-      String previousHash,
-      String blockVersion,
-      int miningDifficulty,
-      List<TransactionOutput> unconsumedOutputs) {
-    this.previousHash = previousHash;
-    this.blockVersion = blockVersion;
-    this.miningDifficulty = miningDifficulty;
-    this.unconsumedOutputs = unconsumedOutputs;
-
-    id = this.calculateId();
-  }
-
   /**
    * The id of this Block. ID of a Block is calculated based on the time stamp, previous hash and
    * block version.
@@ -64,6 +41,33 @@ public class Block {
   private final int miningDifficulty;
 
   /**
+   * The list of unconsumed TransactionOutputs. Those outputs were not yet used up by other
+   * Transactions.
+   */
+  private List<TransactionOutput> unconsumedOutputs;
+
+  /**
+   * Constructor for the Block class.
+   *
+   * @param previousHash the hash of the previous Block
+   * @param blockVersion the version of this Block
+   * @param miningDifficulty the mining difficulty of this Block
+   * @param unconsumedOutputs the pool of unconsumed TransactionOutputs
+   */
+  public Block(
+      String previousHash,
+      String blockVersion,
+      int miningDifficulty,
+      List<TransactionOutput> unconsumedOutputs) {
+    this.previousHash = previousHash;
+    this.blockVersion = blockVersion;
+    this.miningDifficulty = miningDifficulty;
+    this.unconsumedOutputs = unconsumedOutputs;
+
+    id = this.calculateId();
+  }
+
+  /**
    * toString override.
    *
    * @return the text representation of this Block.
@@ -71,33 +75,6 @@ public class Block {
   @Override
   public String toString() {
     return ("Block. ID: " + this.id + " date: " + timeStamp + " version: " + blockVersion);
-  }
-
-  /**
-   * timeStamp getter.
-   *
-   * @return a Date object with the date of creation of this Block.
-   */
-  public Date getTimeStamp() {
-    return this.timeStamp;
-  }
-
-  /**
-   * ID getter.
-   *
-   * @return this Block's ID
-   */
-  public String getId() {
-    return this.id;
-  }
-
-  /**
-   * Hash getter.
-   *
-   * @return this Block's mined hash
-   */
-  public String getHash() {
-    return this.hash;
   }
 
   /**
@@ -161,5 +138,50 @@ public class Block {
     }
 
     return true;
+  }
+
+  /**
+   * timeStamp getter.
+   *
+   * @return a Date object with the date of creation of this Block.
+   */
+  public Date getTimeStamp() {
+    return this.timeStamp;
+  }
+
+  /**
+   * ID getter.
+   *
+   * @return this Block's ID
+   */
+  public String getId() {
+    return this.id;
+  }
+
+  /**
+   * Hash getter.
+   *
+   * @return this Block's mined hash
+   */
+  public String getHash() {
+    return this.hash;
+  }
+
+  /**
+   * Getter of unconsumed outputs of this Transaction.
+   *
+   * @return the unconcumed TransactionOutputs of this Block
+   */
+  public List<TransactionOutput> getUnconsumedOutputs() {
+    return unconsumedOutputs;
+  }
+
+  /**
+   * Setter of unconsumed outputs of this Transaction.
+   *
+   * @param unconsumedOutputs the list of the unconsumed TransactionOutputs
+   */
+  public void setUnconsumedOutputs(List<TransactionOutput> unconsumedOutputs) {
+    this.unconsumedOutputs = unconsumedOutputs;
   }
 }

--- a/blockchain/src/blockchain/Elections.java
+++ b/blockchain/src/blockchain/Elections.java
@@ -1,6 +1,7 @@
 package blockchain;
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,7 +63,7 @@ public class Elections extends Entry {
    * @return this Elections object
    */
   @Override
-  public final Entry processEntry(List<Entry> inputEntries) throws IllegalArgumentException {
+  public final List<TransactionOutput> processEntry(List<TransactionInput> inputEntries) throws IllegalArgumentException {
     if (inputEntries != null) {
       throw new IllegalArgumentException(
           "inputEntries needs to be null in new Elections(ArrayList<Entry> inputEntries");
@@ -79,7 +80,7 @@ public class Elections extends Entry {
                 + electionsQuestion
                 + Arrays.toString(answers));
 
-    return this;
+    return new ArrayList<>(List.of(new TransactionOutput(electionCaller, this)));
   }
 
   /**
@@ -92,7 +93,7 @@ public class Elections extends Entry {
    * @return this Elections object
    * @throws IllegalArgumentException if the inputEntries are different than null
    */
-  public final Entry processEntry() throws IllegalArgumentException {
+  public final List<TransactionOutput> processEntry() throws IllegalArgumentException {
     return (processEntry(null));
   }
 

--- a/blockchain/src/blockchain/Entry.java
+++ b/blockchain/src/blockchain/Entry.java
@@ -12,7 +12,7 @@ public abstract class Entry extends Object {
     this.timeStamp = new Date(System.currentTimeMillis());
   }
 
-  public abstract Entry processEntry(List<Entry> inputEntries) throws IllegalArgumentException;
+  public abstract List<TransactionOutput> processEntry(List<TransactionInput> inputEntries) throws IllegalArgumentException;
 
   public abstract boolean validateEntry();
 

--- a/blockchain/src/blockchain/Tally.java
+++ b/blockchain/src/blockchain/Tally.java
@@ -69,8 +69,12 @@ public class Tally extends Entry {
    * @return
    */
   @Override
-  public final Entry processEntry(List<Entry> inputEntries) throws IllegalArgumentException {
-    return (processEntry(inputEntries.get(0), inputEntries.subList(1, inputEntries.size() - 1)));
+  public final List<TransactionOutput> processEntry(List<TransactionInput> inputEntries) throws IllegalArgumentException {
+    ArrayList<Entry> votes = new ArrayList<>();
+    for(TransactionInput transactionInput : inputEntries.subList(1, inputEntries.size() - 1)) {
+      votes.add(transactionInput.transactionOut.data);
+    }
+    return (processEntry(inputEntries.get(0).transactionOut, votes));
   }
 
   /**
@@ -80,8 +84,9 @@ public class Tally extends Entry {
    * @param votes the list of Vote objects to tally
    * @throws IllegalArgumentException if any of the Vote objects don't match the Elections object or
    *     are itself not validated
+   * @return
    */
-  public final Entry processEntry(Object elections, List<Entry> votes)
+  public final ArrayList<TransactionOutput> processEntry(Object elections, List<Entry> votes)
       throws IllegalArgumentException {
     setElections(elections);
     setVotes(votes);
@@ -93,8 +98,9 @@ public class Tally extends Entry {
    *
    * @throws IllegalArgumentException if any of the Vote objects don't match the Elections object or
    *     are itself not validated
+   * @return
    */
-  public final Entry processEntry() throws RuntimeException {
+  public final ArrayList<TransactionOutput> processEntry() throws RuntimeException {
     if (!elections.validateEntry()) {
       throw new RuntimeException(
           "Entry elections: "
@@ -119,7 +125,7 @@ public class Tally extends Entry {
     }
     updateId();
 
-    return this;
+    return new ArrayList<TransactionOutput>(List.of(new TransactionOutput(teller, this)));
   }
 
   /**

--- a/blockchain/src/blockchain/Transaction.java
+++ b/blockchain/src/blockchain/Transaction.java
@@ -55,14 +55,9 @@ public class Transaction {
    *     inputs
    */
   public List<TransactionOutput> processTransaction() {
-    ArrayList<Entry> inputEntries = new ArrayList<>();
-
-    for (TransactionInput inputTransaction : inputs) {
-      inputEntries.add(inputTransaction.transactionOut.data);
-    }
-
+    List<TransactionOutput> outputs;
     try {
-      data.processEntry(inputEntries);
+      outputs = data.processEntry(inputs);
       calculateHash();
     } catch (Exception e) {
       ArrayList<TransactionOutput> unchangedOutputs = new ArrayList<>();
@@ -71,10 +66,9 @@ public class Transaction {
       }
       return unchangedOutputs;
     }
-    ArrayList<TransactionOutput> updatedOutputs = new ArrayList<>();
-    updatedOutputs.add(new TransactionOutput(signee, data, getId()));
+    outputs.add(new TransactionOutput(signee, data, getId()));
 
-    return updatedOutputs;
+    return outputs;
   }
 
   /**

--- a/blockchain/src/blockchain/Transaction.java
+++ b/blockchain/src/blockchain/Transaction.java
@@ -61,8 +61,16 @@ public class Transaction {
       inputEntries.add(inputTransaction.transactionOut.data);
     }
 
-    data.processEntry(inputEntries);
-    calculateHash();
+    try {
+      data.processEntry(inputEntries);
+      calculateHash();
+    } catch (Exception e) {
+      ArrayList<TransactionOutput> unchangedOutputs = new ArrayList<>();
+      for (TransactionInput inputTransaction : inputs) {
+        unchangedOutputs.add(inputTransaction.transactionOut);
+      }
+      return unchangedOutputs;
+    }
     ArrayList<TransactionOutput> updatedOutputs = new ArrayList<>();
     updatedOutputs.add(new TransactionOutput(signee, data, getId()));
 

--- a/blockchain/src/blockchain/TransactionOutput.java
+++ b/blockchain/src/blockchain/TransactionOutput.java
@@ -4,8 +4,6 @@ import java.security.PublicKey;
 
 /** A representation of the outputs of a Transaction object. */
 public class TransactionOutput {
-  /** The id of this Transaction. */
-  String id;
   /** The public key this TransactionOutput was addressed from. */
   PublicKey author;
   /** Data associated with this TransactionOutput. */

--- a/blockchain/src/blockchain/TransactionOutput.java
+++ b/blockchain/src/blockchain/TransactionOutput.java
@@ -17,7 +17,15 @@ public class TransactionOutput {
     this.parentTransactionId = parentTransactionId;
   }
 
+  TransactionOutput(PublicKey author, Entry data) {
+    this(author, data, null);
+  }
+
   boolean isAddressedFrom(PublicKey key) {
     return key == author;
+  }
+
+  public void setParentTransactionId(String parentTransactionId) {
+    this.parentTransactionId = parentTransactionId;
   }
 }

--- a/blockchain/src/blockchain/Vote.java
+++ b/blockchain/src/blockchain/Vote.java
@@ -1,6 +1,7 @@
 package blockchain;
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -81,13 +82,13 @@ public class Vote extends Entry {
    * @return this Vote object
    */
   @Override
-  public final Entry processEntry(List<Entry> inputEntries) throws IllegalArgumentException {
+  public final List<TransactionOutput> processEntry(List<TransactionInput> inputEntries) throws IllegalArgumentException {
     if (inputEntries.size() != 1) {
       throw new IllegalArgumentException("inputEntries must be of length 1 in new Vote(...)");
     }
 
-    if (inputEntries.get(0) instanceof Elections) {
-      this.elections = (Elections) inputEntries.get(0);
+    if (inputEntries.get(0).transactionOut.data instanceof Elections) {
+      this.elections = (Elections) inputEntries.get(0).transactionOut.data;
     } else {
       throw new IllegalArgumentException("Vote needs Elections to processEntry");
     }
@@ -115,15 +116,18 @@ public class Vote extends Entry {
         StringUtils.hashString(
             StringUtils.keyToString(voter) + elections.getId() + answer + getTimeStamp());
 
-    return this;
+    return new ArrayList<TransactionOutput>(
+
+    );
   }
 
-  public final Entry processEntry(Elections elections) {
-    return (processEntry(Collections.singletonList(elections)));
+  public final List<TransactionOutput> processEntry(TransactionInput inputElections) {
+    return processEntry(new ArrayList<>(List.of(inputElections)));
   }
 
-  public final Entry processEntry() {
-    return (processEntry(Collections.singletonList(elections)));
+  public final List<TransactionOutput> processEntry() {
+    return (processEntry(new ArrayList<TransactionInput>(List.of(
+            new TransactionInput(new TransactionOutput(elections.getElectionsCaller(), elections))))));
   }
 
   /**

--- a/blockchain/src/blockchain/VoteBlock.java
+++ b/blockchain/src/blockchain/VoteBlock.java
@@ -1,5 +1,7 @@
 package blockchain;
 
+import java.util.List;
+
 public class VoteBlock extends Block {
   /**
    * Constructor for the Block class.
@@ -7,8 +9,13 @@ public class VoteBlock extends Block {
    * @param previousHash the hash of the previous Block
    * @param blockVersion the version of this Block
    * @param miningDifficulty the mining difficulty of this Block
+   * @param unconsumedTransactions the list of unconsumed TransactionOutputs
    */
-  public VoteBlock(String previousHash, String blockVersion, int miningDifficulty) {
-    super(previousHash, blockVersion, miningDifficulty);
+  public VoteBlock(
+      String previousHash,
+      String blockVersion,
+      int miningDifficulty,
+      List<TransactionOutput> unconsumedTransactions) {
+    super(previousHash, blockVersion, miningDifficulty, unconsumedTransactions);
   }
 }

--- a/blockchain/test/blockchain/BlockTest.java
+++ b/blockchain/test/blockchain/BlockTest.java
@@ -9,7 +9,7 @@ class BlockTest {
 
   @BeforeEach
   void setUp() {
-    block = new Block("0", "v1", 0);
+    block = new Block("0", "v1", 0, null);
   }
 
   @Test

--- a/blockchain/test/blockchain/ChainTest.java
+++ b/blockchain/test/blockchain/ChainTest.java
@@ -12,7 +12,7 @@ class ChainTest {
 
   @BeforeEach
   void setUp() {
-    Block genesisBlock = new Block("0", "v1", 0);
+    Block genesisBlock = new Block("0", "v1", 0, null);
     genesisBlock.mineHash();
     blockchain = new Chain(genesisBlock);
   }
@@ -26,7 +26,7 @@ class ChainTest {
   @Test
   void isChainValid_WrongPreviousHash() {
     // Chain with a block with a wrong previousHash is not valid
-    Block newBlock = new Block("something", "v1", 0);
+    Block newBlock = new Block("something", "v1", 0, null);
     newBlock.mineHash();
     blockchain.addBlock(newBlock);
     assertFalse(blockchain.isChainValid());
@@ -36,7 +36,7 @@ class ChainTest {
   void addBlock_InvalidBlocksNotAdded() {
     // Invalid blocks are not added to the Chain
     int oldLength = blockchain.size();
-    Block invalidBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0);
+    Block invalidBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0, null);
     assertFalse(blockchain.addBlock(invalidBlock));
     assertEquals(oldLength, blockchain.size());
   }
@@ -44,7 +44,7 @@ class ChainTest {
   @Test
   void addBlock_ReturnsTrueIfAdded() {
     // addBlock returns true if the block is added and chain length is incremented
-    Block validBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0);
+    Block validBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0, null);
     validBlock.mineHash();
     assertTrue(blockchain.addBlock(validBlock));
   }
@@ -52,7 +52,7 @@ class ChainTest {
   @Test
   void addBlock_UpdatesLatestHash() {
     // addBlock updates the latestHash field
-    Block newBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0);
+    Block newBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0, null);
     newBlock.mineHash();
     blockchain.addBlock(newBlock);
     assertEquals(newBlock.getHash(), blockchain.getLatestBlockHash());
@@ -61,7 +61,7 @@ class ChainTest {
   @Test
   void addBlock_IncrementsChainLength() {
     // addBlock increments the chain length
-    Block newBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0);
+    Block newBlock = new Block(blockchain.getLatestBlockHash(), "v1", 0, null);
     newBlock.mineHash();
     int oldSize = blockchain.size();
     blockchain.addBlock(newBlock);


### PR DESCRIPTION
* added the pool of unconsumed TransactionOutputs to Block
* Block now calls Transaction.processTransaction to get the updated pool of the TransactionOutputs
* Entry.processEntry now takes a list of TransactionInputs and outputs TransactionOutputs based on the type of an Entry
* this completely abstracts Transaction from Entry, which is nice
* bad is that there are some static casts in Entry classes, but I don't have a way to fix right now

I also expanded the Block's API to handle searching for active elections and searching for Entry objects by a public key.