### PR TITLE
Expanded tests for Block

### DIFF
--- a/src/main/java/org/votebloke/blockchain/Account.java
+++ b/src/main/java/org/votebloke/blockchain/Account.java
@@ -100,7 +100,6 @@ public class Account {
   public Transaction createElections(String question, String[] answers) {
     Elections elections = new Elections(getPublicKey(), question, answers);
     Transaction electionTransaction = new Transaction(getPublicKey(), elections, null);
-    electionTransaction.processTransaction();
 
     if (getPrivateKey() != null) {
       electionTransaction.sign(getPrivateKey());
@@ -122,7 +121,6 @@ public class Account {
       String answer, Elections elections, ArrayList<TransactionInput> inputTransactions) {
     Vote vote = new Vote(getPublicKey(), elections, answer);
     Transaction voteTransaction = new Transaction(getPublicKey(), vote, inputTransactions);
-    voteTransaction.processTransaction();
 
     if (getPrivateKey() != null) {
       voteTransaction.sign(getPrivateKey());
@@ -145,7 +143,6 @@ public class Account {
   public Transaction tally(ArrayList<TransactionInput> inputTransactions) {
     Tally tally = new Tally(getPublicKey(), null, null);
     Transaction tallyTransaction = new Transaction(getPublicKey(), tally, inputTransactions);
-    tallyTransaction.processTransaction();
 
     if (getPrivateKey() != null) {
       tallyTransaction.sign(getPrivateKey());

--- a/src/main/java/org/votebloke/blockchain/Block.java
+++ b/src/main/java/org/votebloke/blockchain/Block.java
@@ -1,12 +1,12 @@
 package org.votebloke.blockchain;
 
-import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import org.springframework.lang.NonNull;
 
 /** This is a Block class. Represents a single block in the blockchain. */
 public class Block {
@@ -113,17 +113,22 @@ public class Block {
    * Transactions consumed by the transaction and adding the outputs of the transaction.
    *
    * @param transaction the transaction to be added
+   * @return true if the Transaction object was successfully added to the Block; false otherwise
    */
-  public void addTransaction(Transaction transaction) {
+  public boolean addTransaction(@NonNull Transaction transaction) {
     if (transaction.getSignature() == null) {
       getUnsignedTransactions().add(transaction);
-      return;
+      return true;
+    }
+
+    if (!transaction.validate()) {
+      return false;
     }
 
     if (transaction.inputs != null) {
       for (TransactionInput inputTransaction : transaction.inputs) {
         if (!unconsumedOutputs.contains(inputTransaction.transactionOut)) {
-          return;
+          return false;
         }
       }
 
@@ -132,9 +137,8 @@ public class Block {
     }
     unconsumedOutputs.addAll(transaction.outputs);
 
-    if (transaction.validate()) {
-      this.transactions.add(transaction);
-    }
+    this.transactions.add(transaction);
+    return true;
   }
 
   /**
@@ -365,9 +369,10 @@ public class Block {
             .filter(transaction -> transaction.getId().equals(transactionId))
             .findFirst()
             .orElse(null);
-    if (unsignedTransaction != null && unsignedTransaction.setSignature(signature)) {
+    if (unsignedTransaction != null
+        && unsignedTransaction.setSignature(signature)
+        && this.addTransaction(unsignedTransaction)) {
       unsignedTransactions.remove(unsignedTransaction);
-      transactions.add(unsignedTransaction);
     }
   }
 

--- a/src/main/java/org/votebloke/blockchain/Block.java
+++ b/src/main/java/org/votebloke/blockchain/Block.java
@@ -326,6 +326,15 @@ public class Block {
   }
 
   /**
+   * Returns the list of signed and recorded Transaction objects.
+   *
+   * @return the list of Transaction objects recorded in this Transaction
+   */
+  public ArrayList<Transaction> getTransactions() {
+    return this.transactions;
+  }
+
+  /**
    * Returns the hash of the previous Block in the blockchain.
    *
    * @return the hash of the previous Block object in the blockchain
@@ -369,8 +378,6 @@ public class Block {
    * @param base64Signature the base64 decoded signature
    */
   public void signTransaction(String transactionId, String base64Signature) {
-    signTransaction(
-        transactionId,
-        Base64.getDecoder().decode(base64Signature.getBytes(StandardCharsets.UTF_8)));
+    signTransaction(transactionId, Base64.getDecoder().decode(base64Signature));
   }
 }

--- a/src/main/java/org/votebloke/blockchain/StringUtils.java
+++ b/src/main/java/org/votebloke/blockchain/StringUtils.java
@@ -47,7 +47,11 @@ public class StringUtils {
    * @return the 64 base string encoded key
    */
   public static String keyToString(Key key) {
-    return Base64.getEncoder().encodeToString(key.getEncoded());
+    if (key != null) {
+      return Base64.getEncoder().encodeToString(key.getEncoded());
+      } else {
+      return "";
+    }
   }
 
   /**

--- a/src/main/java/org/votebloke/blockchain/StringUtils.java
+++ b/src/main/java/org/votebloke/blockchain/StringUtils.java
@@ -49,7 +49,7 @@ public class StringUtils {
   public static String keyToString(Key key) {
     if (key != null) {
       return Base64.getEncoder().encodeToString(key.getEncoded());
-      } else {
+    } else {
       return "";
     }
   }

--- a/src/main/java/org/votebloke/blockchain/Transaction.java
+++ b/src/main/java/org/votebloke/blockchain/Transaction.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A representation of a single transaction in the blockchain - starting elections, casting a vote,
@@ -47,6 +48,7 @@ public class Transaction {
     this.data = data;
     this.inputs = inputs;
     timeStamp = new Date(System.currentTimeMillis());
+    calculateHash();
   }
 
   /**
@@ -84,7 +86,9 @@ public class Transaction {
   private void calculateHash() {
     id =
         StringUtils.hashString(
-            StringUtils.keyToString(signee) + data.toString() + timeStamp.toString());
+            StringUtils.keyToString(signee)
+                + Optional.ofNullable(data).map(Object::toString).orElse("")
+                + timeStamp.toString());
   }
 
   /**

--- a/src/main/java/org/votebloke/blockchain/Transaction.java
+++ b/src/main/java/org/votebloke/blockchain/Transaction.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
+import org.springframework.lang.NonNull;
 
 /**
  * A representation of a single transaction in the blockchain - starting elections, casting a vote,
@@ -43,12 +43,13 @@ public class Transaction {
    * @param data the data inside this Transaction
    * @param inputs the list of Transaction consisting the input for this Transaction
    */
-  public Transaction(PublicKey signee, Entry data, List<TransactionInput> inputs) {
+  public Transaction(
+      @NonNull PublicKey signee, @NonNull Entry data, List<TransactionInput> inputs) {
     this.signee = signee;
     this.data = data;
     this.inputs = inputs;
     timeStamp = new Date(System.currentTimeMillis());
-    calculateHash();
+    processTransaction();
   }
 
   /**
@@ -59,11 +60,10 @@ public class Transaction {
    * @return the list of outputs corresponding to: this Transaction and unconsumed Transaction from
    *     inputs
    */
-  public List<TransactionOutput> processTransaction() {
+  private List<TransactionOutput> processTransaction() {
     List<TransactionOutput> outputs;
     try {
       outputs = data.processEntry(inputs);
-      calculateHash();
     } catch (Exception e) {
       ArrayList<TransactionOutput> unchangedOutputs = new ArrayList<>();
       for (TransactionInput inputTransaction : inputs) {
@@ -71,6 +71,7 @@ public class Transaction {
       }
       return unchangedOutputs;
     }
+    calculateHash();
     outputs.add(new TransactionOutput(signee, data, getId()));
 
     this.outputs = outputs;
@@ -86,9 +87,7 @@ public class Transaction {
   private void calculateHash() {
     id =
         StringUtils.hashString(
-            StringUtils.keyToString(signee)
-                + Optional.ofNullable(data).map(Object::toString).orElse("")
-                + timeStamp.toString());
+            StringUtils.keyToString(signee) + data.toString() + timeStamp.toString());
   }
 
   /**

--- a/src/test/java/org/votebloke/blockchain/AccountTest.java
+++ b/src/test/java/org/votebloke/blockchain/AccountTest.java
@@ -2,6 +2,8 @@ package org.votebloke.blockchain;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -54,5 +56,13 @@ public class AccountTest {
             (Elections) electionsTransaction.data,
             new ArrayList<TransactionInput>(List.of(new TransactionInput(electionsTransaction))));
     Assertions.assertTrue(voteTransaction.validate());
+  }
+
+  @Test
+  void publicKeyOfAccountConstructedWithStringMatchesOriginalKey()
+      throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeySpecException {
+    PublicKey publicKey = Account.generateKeys().getPublic();
+    Account account = new Account(StringUtils.keyToString(publicKey));
+    Assertions.assertEquals(publicKey, account.getPublicKey());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/BlockTest.java
+++ b/src/test/java/org/votebloke/blockchain/BlockTest.java
@@ -1,17 +1,23 @@
 package org.votebloke.blockchain;
 
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BlockTest {
   Block block;
+  KeyPair keyPair;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
     block = new Block("0", "v1", 0, null);
+    keyPair = Account.generateKeys();
   }
 
   @Test
@@ -48,7 +54,7 @@ class BlockTest {
   }
 
   @Test
-  void getUnconsumedOutputs() {
+  void getUnsignedTransactionsReturnsItemsPassedInConstructor() {
     Transaction testTransaction = new Transaction(null, null, null);
     Block block =
         new Block(
@@ -57,5 +63,34 @@ class BlockTest {
     Assertions.assertArrayEquals(
         (new ArrayList<Transaction>(List.of(testTransaction))).toArray(),
         block.getUnsignedTransactions(null).toArray());
+  }
+
+  @Test
+  void getUnsignedTransactionsUpdatedAfterAddingTransaction() {
+    Elections testElections =
+        new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
+    block.addTransaction(testTransaction);
+
+    Assertions.assertEquals(testTransaction, block.getUnsignedTransactions().get(0));
+  }
+
+  @Test
+  void getUnsignedTransactionsEmptyAfterSigningLastTransaction() {
+    Elections testElections =
+        new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
+    Block testBlock =
+        new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
+
+    String signedData =
+        new String(
+            Base64.encodeBase64(
+                StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
+
+    Assertions.assertDoesNotThrow(
+        () -> testBlock.signTransaction(testTransaction.getId(), signedData));
+
+    Assertions.assertEquals(0, testBlock.getUnsignedTransactions().size());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/BlockTest.java
+++ b/src/test/java/org/votebloke/blockchain/BlockTest.java
@@ -93,5 +93,6 @@ class BlockTest {
 
     Assertions.assertEquals(0, testBlock.getUnsignedTransactions().size());
     Assertions.assertEquals(1, testBlock.getTransactions().size());
+    Assertions.assertEquals(testTransaction.getId(), testBlock.getTransactions().get(0).getId());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/BlockTest.java
+++ b/src/test/java/org/votebloke/blockchain/BlockTest.java
@@ -55,7 +55,9 @@ class BlockTest {
 
   @Test
   void getUnsignedTransactionsReturnsItemsPassedInConstructor() {
-    Transaction testTransaction = new Transaction(null, null, null);
+    Elections testElections =
+            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(),  testElections, null);
     Block block =
         new Block(
             "previousHash", "v1", 0, null, new ArrayList<Transaction>(List.of(testTransaction)));
@@ -94,5 +96,42 @@ class BlockTest {
     Assertions.assertEquals(0, testBlock.getUnsignedTransactions().size());
     Assertions.assertEquals(1, testBlock.getTransactions().size());
     Assertions.assertEquals(testTransaction.getId(), testBlock.getTransactions().get(0).getId());
+  }
+
+  @Test
+  void recordedTransactionsIncrementedAfterSigningTransaction() {
+    Elections testElections =
+            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
+    Block testBlock =
+            new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
+    String signedData =
+            new String(
+                    Base64.encodeBase64(
+                            StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
+
+    Assertions.assertEquals(0, testBlock.getTransactions().size());
+    Assertions.assertDoesNotThrow(
+            () -> testBlock.signTransaction(testTransaction.getId(), signedData));
+    Assertions.assertEquals(1, testBlock.getTransactions().size());
+  }
+
+  @Test
+  void unconsumedTransactionsIncrementedAfterSigningElections() {
+    Elections testElections =
+            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
+    Block testBlock =
+            new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
+    String signedData =
+            new String(
+                    Base64.encodeBase64(
+                            StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
+
+    Assertions.assertEquals(0, testBlock.getUnconsumedOutputs().size());
+    Assertions.assertDoesNotThrow(
+            () -> testBlock.signTransaction(testTransaction.getId(), signedData));
+    Assertions.assertEquals(1, testBlock.getUnconsumedOutputs().size());
+    Assertions.assertEquals(testTransaction.getId(), testBlock.getUnconsumedOutputs().get(0).getParentTransactionId());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/BlockTest.java
+++ b/src/test/java/org/votebloke/blockchain/BlockTest.java
@@ -56,8 +56,8 @@ class BlockTest {
   @Test
   void getUnsignedTransactionsReturnsItemsPassedInConstructor() {
     Elections testElections =
-            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
-    Transaction testTransaction = new Transaction(keyPair.getPublic(),  testElections, null);
+        new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+    Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
     Block block =
         new Block(
             "previousHash", "v1", 0, null, new ArrayList<Transaction>(List.of(testTransaction)));
@@ -101,37 +101,38 @@ class BlockTest {
   @Test
   void recordedTransactionsIncrementedAfterSigningTransaction() {
     Elections testElections =
-            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+        new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
     Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
     Block testBlock =
-            new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
+        new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
     String signedData =
-            new String(
-                    Base64.encodeBase64(
-                            StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
+        new String(
+            Base64.encodeBase64(
+                StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
 
     Assertions.assertEquals(0, testBlock.getTransactions().size());
     Assertions.assertDoesNotThrow(
-            () -> testBlock.signTransaction(testTransaction.getId(), signedData));
+        () -> testBlock.signTransaction(testTransaction.getId(), signedData));
     Assertions.assertEquals(1, testBlock.getTransactions().size());
   }
 
   @Test
   void unconsumedTransactionsIncrementedAfterSigningElections() {
     Elections testElections =
-            new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
+        new Elections(keyPair.getPublic(), "testQuestion", new String[] {"a1"});
     Transaction testTransaction = new Transaction(keyPair.getPublic(), testElections, null);
     Block testBlock =
-            new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
+        new Block("previousHash", "v1", 0, null, new ArrayList<>(List.of(testTransaction)));
     String signedData =
-            new String(
-                    Base64.encodeBase64(
-                            StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
+        new String(
+            Base64.encodeBase64(
+                StringUtils.signWithEcdsa(keyPair.getPrivate(), testTransaction.getSignData())));
 
     Assertions.assertEquals(0, testBlock.getUnconsumedOutputs().size());
     Assertions.assertDoesNotThrow(
-            () -> testBlock.signTransaction(testTransaction.getId(), signedData));
+        () -> testBlock.signTransaction(testTransaction.getId(), signedData));
     Assertions.assertEquals(1, testBlock.getUnconsumedOutputs().size());
-    Assertions.assertEquals(testTransaction.getId(), testBlock.getUnconsumedOutputs().get(0).getParentTransactionId());
+    Assertions.assertEquals(
+        testTransaction.getId(), testBlock.getUnconsumedOutputs().get(0).getParentTransactionId());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/BlockTest.java
+++ b/src/test/java/org/votebloke/blockchain/BlockTest.java
@@ -92,5 +92,6 @@ class BlockTest {
         () -> testBlock.signTransaction(testTransaction.getId(), signedData));
 
     Assertions.assertEquals(0, testBlock.getUnsignedTransactions().size());
+    Assertions.assertEquals(1, testBlock.getTransactions().size());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/StringUtilsTest.java
+++ b/src/test/java/org/votebloke/blockchain/StringUtilsTest.java
@@ -2,6 +2,8 @@ package org.votebloke.blockchain;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.util.StringUtil;
+
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -31,5 +33,14 @@ class StringUtilsTest {
     String encodedKey = StringUtils.keyToString(publicKey);
     PublicKey decodedKey = StringUtils.stringToPublicKey(encodedKey);
     Assertions.assertEquals(publicKey, decodedKey);
+  }
+
+  @Test
+  void dataSignedWithEcdsaIsVerified()
+      throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+    KeyPair keyPair = Account.generateKeys();
+    String dummyData = "data";
+    byte[] encryptedData = StringUtils.signWithEcdsa(keyPair.getPrivate(), dummyData);
+    Assertions.assertTrue(StringUtils.verifyEcdsa(keyPair.getPublic(), dummyData, encryptedData));
   }
 }

--- a/src/test/java/org/votebloke/blockchain/TransactionInputTest.java
+++ b/src/test/java/org/votebloke/blockchain/TransactionInputTest.java
@@ -3,9 +3,19 @@ package org.votebloke.blockchain;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+
 class TransactionInputTest {
   TransactionInput transactionInput;
-  TransactionOutput transactionOutput = new TransactionOutput(new Transaction(null, null, null));
+  TransactionOutput transactionOutput =
+      new TransactionOutput(
+          new Transaction(
+              Account.generateKeys().getPublic(),
+              new Elections(Account.generateKeys().getPublic(), "test", new String[] {"a1"}),
+              null));
+
+  TransactionInputTest() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {}
 
   @Test
   void getTransactionOutReturnsExpectedObject() {

--- a/src/test/java/org/votebloke/blockchain/TransactionInputTest.java
+++ b/src/test/java/org/votebloke/blockchain/TransactionInputTest.java
@@ -1,10 +1,9 @@
 package org.votebloke.blockchain;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class TransactionInputTest {
   TransactionInput transactionInput;

--- a/src/test/java/org/votebloke/blockchain/TransactionTest.java
+++ b/src/test/java/org/votebloke/blockchain/TransactionTest.java
@@ -1,18 +1,32 @@
 package org.votebloke.blockchain;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 
 class TransactionTest {
 
+  KeyPair keyPair;
+  Elections elections;
+
+  @BeforeEach
+  void setUp() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+    keyPair = Account.generateKeys();
+    elections = new Elections(keyPair.getPublic(), "test", new String[] {"ans1"});
+  }
+
   @Test
   void transactionConstructorsDoNotThrow() {
-    Assertions.assertDoesNotThrow(() -> new Transaction(null, null, null));
+    Assertions.assertDoesNotThrow(() -> new Transaction(keyPair.getPublic(), elections, null));
   }
 
   @Test
   void newlyConstructedTransactionHasId() {
-    Transaction transaction = new Transaction(null, null, null);
+    Transaction transaction = new Transaction(keyPair.getPublic(), elections, null);
     Assertions.assertNotNull(transaction.getId());
   }
 }

--- a/src/test/java/org/votebloke/blockchain/TransactionTest.java
+++ b/src/test/java/org/votebloke/blockchain/TransactionTest.java
@@ -1,12 +1,11 @@
 package org.votebloke.blockchain;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class TransactionTest {
 

--- a/src/test/java/org/votebloke/blockchain/TransactionTest.java
+++ b/src/test/java/org/votebloke/blockchain/TransactionTest.java
@@ -1,15 +1,18 @@
 package org.votebloke.blockchain;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TransactionTest {
 
   @Test
-  void processTransaction() {}
+  void transactionConstructorsDoNotThrow() {
+    Assertions.assertDoesNotThrow(() -> new Transaction(null, null, null));
+  }
 
   @Test
-  void generateSignature() {}
-
-  @Test
-  void verifySignature() {}
+  void newlyConstructedTransactionHasId() {
+    Transaction transaction = new Transaction(null, null, null);
+    Assertions.assertNotNull(transaction.getId());
+  }
 }


### PR DESCRIPTION
I have fixed a slew of bugs in this PR.

* added tests to Transaction and Block
* fixed a bug where a Transaction with null fields wouldn't get an id
* fixed a bug where a Block wouldn't remove a Transaction from unsignedTransactions after signing it
* fixed linting
* fixed a bug where Block.signTransaction(String, String) incorrectly decoded the signature from bytes instead of string
* fixed a bug where adding a signed transaction did not increment the unconsumed outputs pool